### PR TITLE
ci: bump node-version 20 -> 22 (pnpm 11 requires >=22.13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
Unblocks CI on main+dev (red since 08-09): workflows pinned Node 20 while pnpm 11 needs >=22.13.

- `ci.yml` node-version 20 -> 22
- `release.yml` node-version 20 -> 22

Note: turbo `type-check` has never actually run under CI (the affected filter is hollow on push events), so the first green run may surface real type errors — those are pre-existing, not introduced here.

Board: MMTE/projects/5 meta CI issue #54.